### PR TITLE
Make it clear you need to clone the repository first

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Privnote is a CLI utility written in go for creating secure self-destructing sec
 * Full compatibility with the privnote service
 * Should be reasonably cross platform? Untested outside of *nix so far
 
-## Installation
+## Installation (from source)
 
 ```bash
+git clone https://github.com/Dombo/privnote.git
+cd privnote
 go build -o privnote && mv privnote /usr/local/bin/privnote
 ```
 


### PR DESCRIPTION
Imho a header "installation" sounds like I'm not building from source locally.
This change adds the commands to download/clone the sources.

Alternatively, the header could be called "build"?